### PR TITLE
update to node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,5 +35,5 @@ inputs:
     default: "10"
 
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/index.js"


### PR DESCRIPTION
Update to node16 to remove the deprecation notices associated with node12.