### PR TITLE
upgrade to NodeJS 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,5 +35,5 @@ inputs:
     default: "10"
 
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"


### PR DESCRIPTION
I use this Action on my workflows and I recently started to get this message from GitHub:

```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: mydea/action-wait-for-api@v1. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```
So this PR does exactly that :D 